### PR TITLE
allow 1 LED gaps to be filled

### DIFF
--- a/marimapper/led.py
+++ b/marimapper/led.py
@@ -214,7 +214,7 @@ def fill_gaps(leds: list[LED3D], max_distance: float = 1.1, max_missing=5):
 
         gap = get_gap(led, next_led) - 1
 
-        if 1.0 < gap <= max_missing:
+        if 1 <= gap <= max_missing:
 
             distance = get_distance(led, next_led)
 


### PR DESCRIPTION
Comparison was for "1.0 <" so the gap had to be more than 1 LED, change to "1 <= " allows single LED gaps to be filled (and comparison can be integer as get_gap returns an integer).

Fixes issue #37 