### PR TITLE
Add <3.12 version constraint to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.12"
 
 maintainers = [
   {name = "TheMariday"},


### PR DESCRIPTION
I'm using [uv](https://docs.astral.sh/uv/) for development (it's very handy). This constraint means it can automatically select the correct python version.