### PR TITLE
Dark frame subtraction

### DIFF
--- a/marimapper/detector.py
+++ b/marimapper/detector.py
@@ -115,10 +115,12 @@ def set_cam_dark(cam: Camera, exposure: int) -> None:
 
 
 def find_led(
-    cam: Camera, threshold: int = 128, display: bool = True
+    cam: Camera, threshold: int = 128, display: bool = True, dark_frame=None
 ) -> Optional[Point2D]:
 
     image = cam.read()
+    if dark_frame is not None:
+        image = cv2.absdiff(image, dark_frame)
     results = find_led_in_image(image, threshold)
 
     if display:
@@ -138,8 +140,10 @@ def enable_and_find_led(
     display: bool = False,
 ) -> Optional[LED2D]:
 
+    dark_frame = cam.read()
+
     # First wait for no leds to be visible
-    while find_led(cam, threshold, display) is not None:
+    while find_led(cam, threshold, display, dark_frame=dark_frame) is not None:
         pass
 
     # Set the led to on and start the clock
@@ -152,7 +156,7 @@ def enable_and_find_led(
     while (
         point is None and time.time() < response_time_start + timeout_controller.timeout
     ):
-        point = find_led(cam, threshold, display)
+        point = find_led(cam, threshold, display, dark_frame)
 
     led_backend.set_led(led_id, False)
 
@@ -161,7 +165,7 @@ def enable_and_find_led(
 
     timeout_controller.add_response_time(time.time() - response_time_start)
 
-    while find_led(cam, threshold, display) is not None:
+    while find_led(cam, threshold, display, dark_frame=dark_frame) is not None:
         pass
 
     return LED2D(led_id, view_id, point)

--- a/marimapper/detector_process.py
+++ b/marimapper/detector_process.py
@@ -86,9 +86,13 @@ class DetectorProcess(Process):
 
                 # scan start here
                 set_cam_dark(cam, self._dark_exposure)
+                dark_frame = cam.read()
 
                 # Firstly, if there are leds visible, break out
-                if find_led(cam, self._threshold, self._display) is not None:
+                if (
+                    find_led(cam, self._threshold, self._display, dark_frame=dark_frame)
+                    is not None
+                ):
                     logger.error(
                         "Detector process can detect an LED when no LEDs should be visible"
                     )


### PR DESCRIPTION
Here's a proof of concept for doing dark frame subtraction. It takes an image before turning on the LED, then subtracts that image from the one taken when the LED is on.

This results in an extremely clean image. The only disadvantage is that it's very sensitive to anything moving in frame - even sub-pixel movements can become visible.

This managed to accurately detect LEDs in a large room with my (old) Macbook Pro webcam and no exposure adjustments. I think exposure adjustment may still be valuable, but this makes it much less necessary.

This might not be the neatest way of doing it, as I hacked a lot of stuff around on Friday. I've refactored this a bit without testing because I don't actually have any easily-accessible LEDs at home...

I'd recommend giving it a try with your test setup and see how it works.

ref #33 