### PR TITLE
Throttle frame rate of GUI processes to 60fps

### DIFF
--- a/marimapper/detector_process.py
+++ b/marimapper/detector_process.py
@@ -1,4 +1,5 @@
 from multiprocessing import get_logger, Process, Queue, Event
+import time
 from marimapper.detector import (
     show_image,
     set_cam_default,
@@ -159,6 +160,7 @@ class DetectorProcess(Process):
                 if self._display:
                     image = cam.read()
                     show_image(image)
+                    time.sleep(1 / 60)
 
         logger.info("resetting cam!")
         set_cam_default(cam)

--- a/marimapper/visualize_process.py
+++ b/marimapper/visualize_process.py
@@ -60,6 +60,7 @@ class VisualiseProcess(Process):
 
             self._vis.poll_events()
             self._vis.update_renderer()
+            time.sleep(1 / 60)
 
     def initialise_visualiser__(self):
         logger.debug("Renderer3D process initialising visualiser")


### PR DESCRIPTION
At the moment these processes are constantly looping and consuming CPU while the scan command is running. This eats laptop battery life surprisingly quickly and probably slows things down.