### PR TITLE
Fix pixelblaze map uploading (AttributeError)

### DIFF
--- a/marimapper/backends/pixelblaze/upload_map_to_pixelblaze.py
+++ b/marimapper/backends/pixelblaze/upload_map_to_pixelblaze.py
@@ -48,6 +48,7 @@ def upload_map_to_pixelblaze(cli_args):
         f"Uploading coordinates to pixelblaze {cli_args.server if cli_args.server is not None else ''}"
     )
 
-    led_backend = pixelblaze_backend.pixelblaze_backend_factory(cli_args)
+    backend_factory = pixelblaze_backend.pixelblaze_backend_factory(cli_args)
+    led_backend = backend_factory()
     led_backend.set_map_coordinates(final_coordinate_list)
     logger.info("Finished")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "marimapper"
-version = "V3.4.1"
+version = "V3.4.2"
 
 dependencies = [
     "numpy",


### PR DESCRIPTION
On current latest, running `marimapper_upload_mapping_to_pixelblaze` via CLI will fail with an `AttributeError`:
```
AttributeError: 'functools.partial' object has no attribute 'set_map_coordinates'
```
This PR just instantiates the type that the factory function returns. I copied the general format that `check_backend_cli.py` used. Tested with an actual pixelblaze board, and this let me upload the map. 